### PR TITLE
Keep error details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	connectrpc.com/connect v1.11.1
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98
 	google.golang.org/grpc v1.58.1
 	google.golang.org/protobuf v1.31.0
 )
@@ -13,5 +14,4 @@ require (
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 )

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package connectgateway
 
-const Version = "0.2.2"
+const Version = "0.3.0"


### PR DESCRIPTION
Thank you for this great library. It saves a lot of needless boilerplate!
I noticed errordetails are completely lost (status.Status.Details field).

This patch maps the details field properly from the connect error into grpc status error.