### PR TITLE
Avoid panic when converting HTTP headers to gRPC metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
+	gotest.tools/v3 v3.5.1
 )
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
 golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
@@ -20,3 +21,5 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/metadata.go
+++ b/metadata.go
@@ -6,9 +6,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func metadataFromHeader(in http.Header) (out metadata.MD) {
-	for k, v := range in {
-		out.Set(k, v...)
+func metadataFromHeader(in http.Header) metadata.MD {
+	out := metadata.New(nil)
+	for k, vals := range in {
+		out.Set(k, vals...)
 	}
-	return
+	return out
 }

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,60 @@
+package connectgateway
+
+import (
+	"net/http"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+	"gotest.tools/v3/assert"
+)
+
+func TestMetadataFromHeader(t *testing.T) {
+	for _, params := range []struct {
+		name string
+		in   http.Header
+		want metadata.MD
+	}{
+		{
+			"empty header",
+			make(http.Header),
+			metadata.New(nil),
+		},
+		{
+			"non-empty header",
+			nonEmptyHeader(),
+			nonEmptyMetadata(),
+		},
+		{
+			"non-empty header with duplicates",
+			nonEmptyHeaderWithDuplicates(),
+			nonEmptyMetadataWithDuplicates(),
+		},
+	} {
+		t.Run(params.name, func(t *testing.T) {
+			got := metadataFromHeader(params.in)
+			assert.DeepEqual(t, params.want, got)
+		})
+	}
+}
+
+func nonEmptyHeader() http.Header {
+	h := make(http.Header)
+	h.Set("ETag", "123-a")
+	return h
+}
+
+func nonEmptyHeaderWithDuplicates() http.Header {
+	h := nonEmptyHeader()
+	h.Add("ETag", "123-b")
+	return h
+}
+
+func nonEmptyMetadata() metadata.MD {
+	return metadata.New(map[string]string{"ETag": "123-a"})
+}
+
+func nonEmptyMetadataWithDuplicates() metadata.MD {
+	md := nonEmptyMetadata()
+	md.Append("ETag", "123-b")
+	return md
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package connectgateway
 
-const Version = "0.3.0"
+const Version = "0.3.1"


### PR DESCRIPTION
metadata.MD is a map. If not initialized explicitly, calling Set panics.