### PR TITLE
Convert and forward Connect errors metadata

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -65,6 +65,11 @@ func NewUnaryHandler[Req, Res any](
 			if !errors.As(err, &perr) {
 				return nil, status.Error(codes.Code(connect.CodeOf(err)), err.Error())
 			}
+			if h := perr.Meta(); len(h) > 0 {
+				if err := grpc.SendHeader(ctx, metadataFromHeader(h)); err != nil {
+					return nil, err
+				}
+			}
 			st := &spb.Status{
 				Code:    int32(perr.Code()),
 				Message: perr.Message(),


### PR DESCRIPTION
we forward response headers from the response in non-error cases, however in error cases we don't do it. Effectively, response headers are entirely dropped right now, if it's an error response. this patch reads from connect.Error and forwards these headers.