### PR TITLE
Update dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Connect-Gateway
 
-[![PkgGoDev](https://pkg.go.dev/badge/go.vallahaye.net/connect-gateway)](https://pkg.go.dev/go.vallahaye.net/connect-gateway) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/vallahaye/connect-gateway) [![GoReportCard](https://goreportcard.com/badge/github.com/vallahaye/connect-gateway)](https://goreportcard.com/badge/github.com/vallahaye/connect-gateway) ![GitHub](https://img.shields.io/github/license/vallahaye/connect-gateway)
+[![Go Reference](https://pkg.go.dev/badge/go.vallahaye.net/connect-gateway.svg)](https://pkg.go.dev/go.vallahaye.net/connect-gateway)
+[![Go Report Card](https://goreportcard.com/badge/go.vallahaye.net/connect-gateway)](https://goreportcard.com/report/go.vallahaye.net/connect-gateway)
 
-The Connect-Gateway introduces direct binding from [gRPC-Gateway](https://grpc-ecosystem.github.io/grpc-gateway/) local handlers to [Connect](https://connect.build/) service handlers. It addresses the recurring request to support Google API HTTP annotations in Connect:
+The Connect-Gateway introduces direct binding from [gRPC-Gateway](https://grpc-ecosystem.github.io/grpc-gateway/) local handlers to [Connect](https://connectrpc.com/) service handlers. It addresses the recurring request to support Google API HTTP annotations in Connect:
 
-- [Service option for Connect HTTP path #468](https://github.com/bufbuild/connect-go/issues/468)
-- [`google.api.Http` annotation support #274](https://github.com/bufbuild/connect-go/issues/274)
+- [Service option for Connect HTTP path #468](https://github.com/connectrpc/connect-go/issues/468)
+- [`google.api.Http` annotation support #274](https://github.com/connectrpc/connect-go/issues/274)
 
-We provide a complete solution for the two to communicate seamlessly through simple function calls, without relying on network communications. All of which is done by reusing as much of the code from both projects as possible and mimicking the [connect-go](https://github.com/bufbuild/connect-go) implementation, i.e. reducing code generation as much as possible, with most of the logic being provided in a library.
+We provide a complete solution for the two to communicate seamlessly through simple function calls, without relying on network communications. All of which is done by reusing as much of the code from both projects as possible and mimicking the [connect-go](https://github.com/connectrpc/connect-go) implementation, i.e. reducing code generation as much as possible, with most of the logic being provided in a library.
 
 ## Features
 
@@ -18,8 +19,8 @@ We provide a complete solution for the two to communicate seamlessly through sim
 
 ## Limitations
 
-- No support for streaming calls as [it is not yet supported by the gRPC-Gateway's "in-process" transport mode](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/protoc-gen-grpc-gateway/internal/gengateway/template.go#L609)
-- Uninitialized [Request.Peer](https://pkg.go.dev/github.com/bufbuild/connect-go#Request.Peer) and [Request.Spec](https://pkg.go.dev/github.com/bufbuild/connect-go#Request.Spec) properties on Connect requests as it cannot be set externally
+- No support for streaming calls as [it is not yet supported by the gRPC-Gateway's "in-process" transport mode](https://github.com/grpc-ecosystem/grpc-gateway/blob/main/protoc-gen-grpc-gateway/internal/gengateway/template.go#L621)
+- Uninitialized [Request.Peer](https://pkg.go.dev/connectrpc.com/connect#Request.Peer) and [Request.Spec](https://pkg.go.dev/connectrpc.com/connect#Request.Spec) properties on Connect requests as it cannot be set externally
 
 ## Example
 


### PR DESCRIPTION
The Connect Git repository is now hosted at https://github.com/connectrpc/connect-go. Documentation is available at https://connectrpc.com and https://pkg.go.dev/connectrpc.com/connect.

Closes #54